### PR TITLE
Update base.py

### DIFF
--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -256,7 +256,10 @@ class Base(object):
 
         # 这里使用 jinjia2 做模板，比单纯替换要好一些
         tmp = Template(s)
-        html = tmp.render(opt=my_option.decode('utf8'), chartid=divid)
+        try:
+            html = tmp.render(opt=my_option, chartid=divid)
+        except:
+            html = tmp.render(opt=my_option.decode('utf8'), chartid=divid)
 
         return html
 


### PR DESCRIPTION
The default of string encoding is utf8  when I use pychart in python3, so I add `try...except` to avoid the exception.